### PR TITLE
fix ubuntu build and update All Paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-LIB_FLAGS = -lgraphblas -llagraph -llagraphx
+LIB_FLAGS = -L/usr/local/lib -Wl,-rpath,/usr/local/lib -lgraphblas -llagraph -llagraphx
 INCLUDE_FLAGS = -I/usr/local/include/suitesparse -I./ -I./src -I./src/adapters
 ALGO_PATH=../LAGraph/experimental/algorithm/LAGraph_CFL_reachability_advanced.c
 ALGO_OPT_PATH=../LAGraph/experimental/algorithm/LAGraph_CFL_optimized_matrix_opt.c

--- a/src/adapters/adapter_CFL_all_path.c
+++ b/src/adapters/adapter_CFL_all_path.c
@@ -64,8 +64,8 @@ static GrB_Info adapter_CFL_init_outputs() {
 //
 // this should be called after adapter_CFL_adv_init_outputs
 static GrB_Info adapter_CFL_run() {
-    TRY(LAGraph_CFL_AllPaths(state.outputs, state.adj_matrices, &state.all_path_type, state.terms_count,
-                             state.nonterms_count, state.rules, state.rules_count, state.msg));
+    TRY(LAGraph_CFL_AllPaths(state.outputs, &state.all_path_type, state.adj_matrices, state.terms_count,
+                             state.nonterms_count, state.rules, state.rules_count, state.msg, 0));
 
     return GrB_SUCCESS;
 }
@@ -90,8 +90,8 @@ static size_t adapter_CFL_get_result() {
 //
 // this should be called after each run of the algorithm
 static GrB_Info adapter_CFL_free_outputs() {
-    TRY(GrB_free(&state.all_path_type));
-    TRY(adapter_CFL_free_outputs_common(&state.outputs, state.nonterms_count, state.msg));
+    LAGraph_CFL_AllPaths_free_outputs(state.outputs, state.nonterms_count, &state.all_path_type);
+    state.outputs = NULL;
 
     return GrB_SUCCESS;
 }

--- a/src/adapters/adapter_CFL_single_path.c
+++ b/src/adapters/adapter_CFL_single_path.c
@@ -89,8 +89,8 @@ static size_t adapter_CFL_get_result() {
 //
 // this should be called after each run of the algorithm
 static GrB_Info adapter_CFL_free_outputs() {
-    TRY(GrB_free(&state.pi_type));
     TRY(adapter_CFL_free_outputs_common(&state.outputs, state.nonterms_count, state.msg));
+    TRY(GrB_free(&state.pi_type));
 
     return GrB_SUCCESS;
 }


### PR DESCRIPTION
Из-за того, что в убунте лежит graphblas 7 версии, по умолчанию компилируется он. Поэтому сингл паф и алл паф не работают

И ещё обновил до последней версии All path, и, как я понимаю, раньше внутренности outputs матриц не очищались, сейчас для этого добавлена функция

И ещё прикладываю три файла LAGraph'a: experimental/algorithm
[LAGraph_CFL_AllPaths.c](https://github.com/user-attachments/files/26980540/LAGraph_CFL_AllPaths.c)

experimental/test
[test_CFL_AllPaths.c](https://github.com/user-attachments/files/26980568/test_CFL_AllPaths.c)


и include/
[LAGraphX.h.c](https://github.com/user-attachments/files/26980581/LAGraphX.h.c)
(добавил .c, чтобы получилось загрузить на гитхаб)

Чтобы обновить ветку со всеми алгоритмами