### PR TITLE
Fix rsm templates and refactor infrastructure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,15 +31,15 @@ jobs:
                   git clone https://github.com/SparseLinearAlgebra/LAGraph.git
                   cd LAGraph
                   git switch homka122/all_algorithms_benchmark
-                  make
+                  CMAKE_OPTIONS="-G Ninja" make
                   sudo make install
                   cd ..
 
             - name: Build benchmark
               run: |
-                  make bench
+                  make
 
             - name: Run benchmark
               run: |
                   export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
-                  ./build/test -efblt -c configs/configs_my.csv -a CFL_adv -r 3 --hot
+                  make CI

--- a/Makefile
+++ b/Makefile
@@ -1,86 +1,32 @@
-LIB_FLAGS = -L/usr/local/lib -Wl,-rpath,/usr/local/lib -lgraphblas -llagraph -llagraphx
-INCLUDE_FLAGS = -I/usr/local/include/suitesparse -I./ -I./src -I./src/adapters
-ALGO_PATH=../LAGraph/experimental/algorithm/LAGraph_CFL_reachability_advanced.c
-ALGO_OPT_PATH=../LAGraph/experimental/algorithm/LAGraph_CFL_optimized_matrix_opt.c
-ALGO_I=-I../LAGraph/src/utility
-ALGO_OBJ = LAGraph_CFL_reachability_advanced.o
-ALGO_OPT_OBJ=LAGraph_CFL_optimized_matrix_opt.o
-ALGO_OBJ_V = LAGraph_CFL_reachability_advanced_V.o
+CC ?= gcc
+SRC_DIR := src
 
-all: bench_compile_v
+BUILD_DIR ?= build
+TARGET := $(BUILD_DIR)/cfg_bench
 
-LAGraph_CFL_optimized_matrix_opt.o: ../LAGraph/experimental/algorithm/LAGraph_CFL_optimized_matrix_opt.c
+CFLAGS ?= -O2 -Wall -Wextra -Wpedantic -Wno-sign-compare
+INCLUDES := -I/usr/local/include/suitesparse -I$(SRC_DIR) -I$(SRC_DIR)/adapters
+LDLIBS := -lgraphblas -llagraph -llagraphx
 
-$(ALGO_OBJ): ${ALGO_PATH} ${ALGO_OPT_OBJ}
-	gcc ${ALGO_PATH} ${ALGO_OPT_PATH}  ${INCLUDE_FLAGS} ${ALGO_I} -o $@
+SRCS := $(wildcard $(SRC_DIR)/*.c) $(wildcard $(SRC_DIR)/adapters/*.c)
 
-$(ALGO_OPT_OBJ): ${ALGO_OPT_PATH}
-	gcc -c ${ALGO_OPT_PATH} ${INCLUDE_FLAGS} ${ALGO_I} -o $@
+.PHONY: all clean bench debug
 
-$(ALGO_OBJ_V): ${ALGO_PATH}
-	gcc -c -g  ${ALGO_PATH} -DBENCH_CFL_REACHBILITY ${INCLUDE_FLAGS} ${ALGO_I} -o $@
+all: $(TARGET)
 
-build: test.c parser.c
-	gcc test.c parser.c ${ALGO} ${LIB_FLAGS} ${INCLUDE_FLAGS} \
- -o test -O2 -Wextra -Wno-sign-compare -pedantic \
+$(TARGET): $(SRCS)
+	mkdir -p $(BUILD_DIR)
+	$(CC) $(CFLAGS) $(INCLUDES) $^ $(LDLIBS) -o $@
 
-build-debug: test.c parser.c
-	gcc test.c parser.c ${ALGO} ${LIB_FLAGS} ${INCLUDE_FLAGS} \
- -o test -g -Wextra -Wno-sign-compare -pedantic -fsanitize=undefined \
- 
+bench: $(TARGET)
+	./$(TARGET) -c configs/configs_my.csv -r 10 --hot
 
-run: test.c parser.c
-	gcc test.c parser.c ${ALGO} ${LIB_FLAGS} ${INCLUDE_FLAGS} \
- -o test -Wextra -Wno-sign-compare -pedantic -fsanitize=undefined -DDEBUG_parser \
- && ./test
+CI: $(TARGET)
+	./$(TARGET) -t -c configs/configs_my.csv
 
-bench: src/test.c src/parser.c src/adapters/*.c src/symbol_list.c src/grammar.c src/memory.c src/result_manager.c src/rsm.c
-	gcc src/test.c src/parser.c src/adapters/*.c src/symbol_list.c src/grammar.c src/memory.c src/result_manager.c src/rsm.c -O2 ${LIB_FLAGS} ${INCLUDE_FLAGS} -o build/test
+debug: clean
+	$(MAKE) BUILD_DIR=build/debug \
+		CFLAGS="-g -O0 -Wall -Wextra -Wpedantic -Wno-sign-compare"
 
-bench_compile: src/test.c src/parser.c src/adapters/*.c src/symbol_list.c src/grammar.c src/memory.c src/result_manager.c src/rsm.c ${ALGO_PATH} ${ALGO_OPT_PATH}
-	gcc src/test.c src/parser.c src/adapters/*.c src/symbol_list.c src/grammar.c src/memory.c src/result_manager.c src/rsm.c ${ALGO_PATH} ${ALGO_OPT_PATH} ${ALGO_I} -O2 ${LIB_FLAGS} ${INCLUDE_FLAGS} -o build/test
-
-bench_debug: src/test.c src/parser.c src/adapters/*.c src/symbol_list.c src/grammar.c src/memory.c src/result_manager.c src/rsm.c ${ALGO_PATH} ${ALGO_OPT_PATH}
-	gcc src/test.c src/parser.c src/adapters/*.c src/symbol_list.c src/grammar.c src/memory.c src/result_manager.c src/rsm.c ${ALGO_PATH} ${ALGO_OPT_PATH} ${ALGO_I} -O0 -g ${LIB_FLAGS} ${INCLUDE_FLAGS} -o build/test
-
-bench-CI: src/test.c src/parser.c src/adapters/*.c src/symbol_list.c src/grammar.c src/memory.c src/result_manager.c src/rsm.c
-	gcc src/test.c src/parser.c src/adapters/*.c src/symbol_list.c src/grammar.c src/memory.c src/result_manager.c src/rsm.c -O2 -DCI ${LIB_FLAGS} ${INCLUDE_FLAGS} -o build/test
-
-test_compile: test.c parser.c ${ALGO_OBJ}
-	gcc test.c parser.c ${ALGO_OBJ} -O2 ${ALGO} ${LIB_FLAGS} ${INCLUDE_FLAGS} ${ALGO_I} \
-		-o test && ./test -${FLAGS}t
-
-bench_compile_v: test.c parser.c ${ALGO_OBJ_V}
-	gcc test.c parser.c ${ALGO_OBJ_V} -O2 -g ${ALGO} ${LIB_FLAGS} ${INCLUDE_FLAGS} ${ALGO_I} \
-		-o test && ./test -${FLAGS}
-
-bench_compile_v_leak: test.c parser.c
-	gcc test.c parser.c -fsanitize=address,leak ${ALGO_PATH} ${ALGO_OPT_PATH} -g -O2 ${ALGO} ${LIB_FLAGS} ${INCLUDE_FLAGS} ${ALGO_I} \
-		-o test && ./test -${FLAGS}
-
-deb: test.c parser.c ${ALGO_PATH}
-	gcc test.c parser.c -DBENCH_CFL_REACHBILITY -DDEBUG_parser -o test -O0 -g -Wextra -Wall -pedantic ${ALGO_PATH} ${LIB_FLAGS} ${INCLUDE_FLAGS} ${ALGO_I} && echo OK
-
-debug: test.c parser.c
-	gcc test.c parser.c  ${ALGO} \
-${LIB_FLAGS} ${INCLUDE_FLAGS} \
- -g -o test -Wextra -Wall -pedantic -fsanitize=address,undefined -DDEBUG \
- && ./test
-
-debug-info: test.c parser.c
-	gcc test.c parser.c  ${ALGO} \
-${LIB_FLAGS} ${INCLUDE_FLAGS} \
- -g -o test -Wno-sign-compare -pedantic -DDEBUG \
- && ./test
-
-convert: convert.c
-	gcc convert.c -o convert -Wextra -Wall -pedantic && time ./convert
-
-# Code formatting with clang-format
-FORMAT_SOURCES = src/*.c src/*.h src/adapters/*.c src/adapters/*.h tests/*.c
-
-format:
-	clang-format -i $(FORMAT_SOURCES)
-
-format-check:
-	clang-format --dry-run -Werror $(FORMAT_SOURCES)
+clean:
+	rm -rf build

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ bench: $(TARGET)
 	./$(TARGET) -c configs/configs_my.csv -r 10 --hot
 
 CI: $(TARGET)
-	./$(TARGET) -t -c configs/configs_my.csv
+	./$(TARGET) -efblt -c configs/configs_my.csv
 
 debug: clean
 	$(MAKE) BUILD_DIR=build/debug \

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@
     cd CFG_bench
     gdown 12Qhc6XNXYbpPbZGp-lo30NsywFELAFhu
     unzip CFPQ_eval.zip -d .
-    make bench
-    ./build/test -c configs/configs_my.csv -r 10 --hot
+    make
+    ./build/cfg_bench -c configs/configs_my.csv -r 10 --hot
     ```
     After unpacking, the benchmark data will be available in the `data` folder.
-    Run `./build/test -h` to print the CLI help message with descriptions of all available options.
+    Run `./build/cfg_bench -h` to print the CLI help message with descriptions of all available options.
 4. _(Optional)_ To use different graphs and grammars, upload the required files to the `data` folder.
 
 ## Benchmark Configuration
@@ -39,7 +39,7 @@
 The benchmark reads its input set from a CSV file passed with `-c`:
 
 ```bash
-./build/test -c configs/configs_my.csv
+./build/cfg_bench -c configs/configs_my.csv
 ```
 
 Use `-r` to set the number of benchmark rounds and `--hot` to enable the HOT launch warm-up run.
@@ -77,7 +77,7 @@ To add a custom benchmark configuration:
    Pass the file with `-c`:
 
    ```bash
-   ./build/test -c configs/your_config.csv
+   ./build/cfg_bench -c configs/your_config.csv
    ```
 
 No source code changes are required.

--- a/configs/configs_cfl_fast.csv
+++ b/configs/configs_cfl_fast.csv
@@ -1,0 +1,11 @@
+data/graphs/rdf/eclass.g,data/grammars/nested_parentheses_subClassOf_type.cnf,90994
+data/graphs/rdf/go.g,data/grammars/nested_parentheses_subClassOf_type.cnf,640316
+data/graphs/rdf/go_hierarchy.g,data/grammars/nested_parentheses_subClassOf_type.cnf,588976
+data/graphs/rdf/taxonomy.g,data/grammars/nested_parentheses_subClassOf_type.cnf,151706
+data/graphs/rdf/taxonomy_hierarchy.g,data/grammars/nested_parentheses_subClassOf_type.cnf,5351657
+data/graphs/c_alias/init.g,data/grammars/c_alias.cnf,3783769
+data/graphs/c_alias/mm.g,data/grammars/c_alias.cnf,3990305
+data/graphs/java/lusearch.g,data/grammars/java_points_to.cnf,9242
+data/graphs/java/sunflow.g,data/grammars/java_points_to.cnf,16354
+data/graphs/vf/nab.g,data/grammars/vf.cnf,739646
+data/graphs/aa/povray.g,data/grammars/aa.cnf,27219043

--- a/src/adapters/adapter_CFL.c
+++ b/src/adapters/adapter_CFL.c
@@ -41,6 +41,7 @@ static GrB_Info adapter_CFL_setup() {
 //
 // adapter_CFL_prepare should be called just once for each config
 static GrB_Info adapter_CFL_prepare(ParserResult parser_result, void *prepare_data) {
+    (void)prepare_data;
     TRY(adapter_CFL_prepare_common(parser_result, &state.adj_matrices, &state.terms_count, &state.nonterms_count,
                                    &state.rules, &state.rules_count, &state.graph_size));
 
@@ -72,7 +73,11 @@ static GrB_Info adapter_CFL_run() {
 static ResultType adapter_CFL_is_result_valid(size_t valid_result) {
     // TODO: combine indexed matrices if initial nonterm is indexed
     ResultType is_valid = RESULT_UNKNOWN;
-    TRY(adapter_CFL_is_result_valid_common(state.outputs[0], valid_result, &is_valid));
+    GrB_Info info = adapter_CFL_is_result_valid_common(state.outputs[0], valid_result, &is_valid);
+    if (info < GrB_SUCCESS) {
+        fprintf(stderr, "LAGraph failure (file %s, line %d): (%d, msg: %s) \n", __FILE__, __LINE__, info, state.msg);
+        return RESULT_UNKNOWN;
+    }
     return is_valid;
 }
 
@@ -103,7 +108,10 @@ static GrB_Info adapter_CFL_cleanup() {
 }
 
 // free LAGraph\GraphBLAS resources
-static GrB_Info adapter_CFL_teardown() { TRY(LAGraph_Finalize(state.msg)); }
+static GrB_Info adapter_CFL_teardown() {
+    TRY(LAGraph_Finalize(state.msg));
+    return GrB_SUCCESS;
+}
 
 // get the methods of the adapter
 AdapterMethods adapter_CFL_get_methods() {

--- a/src/adapters/adapter_CFL_CFPQ_RSM.c
+++ b/src/adapters/adapter_CFL_CFPQ_RSM.c
@@ -90,15 +90,7 @@ static GrB_Info adapter_CFL_prepare(ParserResult parser_result, void *prepare_da
             }
         }
 
-        {
-            GrB_Info LG_GrB_Info = GxB_Matrix_build_Scalar(prepared_adj_matrices[i], row, col, true_scalar, count);
-            if (LG_GrB_Info < GrB_SUCCESS) {
-                fprintf(stderr, "LAGraph failure (file %s, line %d): (%d, msg: %s) \n",
-                        "/home/homka/code/spbu/course_work/CFG_bench/src/adapters/adapter_CFL_CFPQ_RSM.c", 94,
-                        LG_GrB_Info, state.msg);
-                return (LG_GrB_Info);
-            }
-        }
+        TRY(GxB_Matrix_build_Scalar(prepared_adj_matrices[i], row, col, true_scalar, count));
 #ifdef DEBUG_parser
         GxB_print(prepared_adj_matrices[i], 1);
 #endif

--- a/src/adapters/adapter_CFL_CFPQ_RSM.c
+++ b/src/adapters/adapter_CFL_CFPQ_RSM.c
@@ -44,6 +44,7 @@ static GrB_Info adapter_CFL_setup() {
 //
 // adapter_CFL_prepare should be called just once for each config
 static GrB_Info adapter_CFL_prepare(ParserResult parser_result, void *prepare_data) {
+    (void)prepare_data;
     Grammar grammar = parser_result.grammar;
     Graph graph = parser_result.graph;
     SymbolList list = parser_result.symbols;
@@ -138,6 +139,7 @@ static GrB_Info adapter_CFL_run() {
 //
 // TODO: now check only count of reachibility pairs, make this more generic for other adapters
 static ResultType adapter_CFL_is_result_valid(size_t valid_result) {
+    (void)valid_result;
     return RESULT_UNKNOWN;
     // bool is_valid = false;
     // TRY(adapter_CFL_is_result_valid_common(state.outputs[0], valid_result, &is_valid));
@@ -171,7 +173,10 @@ static GrB_Info adapter_CFL_cleanup() {
 }
 
 // free LAGraph\GraphBLAS resources
-static GrB_Info adapter_CFL_teardown() { TRY(LAGraph_Finalize(state.msg)); }
+static GrB_Info adapter_CFL_teardown() {
+    TRY(LAGraph_Finalize(state.msg));
+    return GrB_SUCCESS;
+}
 
 // get the methods of the adapter
 AdapterMethods adapter_CFL_CFPQ_RSM_get_methods() {

--- a/src/adapters/adapter_CFL_CFPQ_RSM.c
+++ b/src/adapters/adapter_CFL_CFPQ_RSM.c
@@ -100,7 +100,7 @@ static GrB_Info adapter_CFL_prepare(ParserResult parser_result, void *prepare_da
     state.adj_matrices = prepared_adj_matrices;
     state.V = graph.node_count;
 
-    adapter_CFL_init_src_nodes_common(&state.sources, &state.sources_num);
+    adapter_CFL_init_src_nodes_common(&state.sources, &state.sources_num, 0);
 
     free(row);
     free(col);

--- a/src/adapters/adapter_CFL_adv.c
+++ b/src/adapters/adapter_CFL_adv.c
@@ -168,7 +168,11 @@ static GrB_Info adapter_CFL_adv_run() {
 // TODO: now check only count of reachibility pairs, make this more generic for other adapters
 static ResultType adapter_CFL_adv_is_result_valid(size_t valid_result) {
     ResultType is_valid = RESULT_UNKNOWN;
-    TRY(adapter_CFL_is_result_valid_common(state.outputs[0], valid_result, &is_valid));
+    GrB_Info info = adapter_CFL_is_result_valid_common(state.outputs[0], valid_result, &is_valid);
+    if (info < GrB_SUCCESS) {
+        fprintf(stderr, "LAGraph failure (file %s, line %d): (%d, msg: %s) \n", __FILE__, __LINE__, info, state.msg);
+        return RESULT_UNKNOWN;
+    }
     return is_valid;
 }
 

--- a/src/adapters/adapter_CFL_all_path.c
+++ b/src/adapters/adapter_CFL_all_path.c
@@ -45,6 +45,7 @@ static GrB_Info adapter_CFL_setup() {
 //
 // adapter_CFL_prepare should be called just once for each config
 static GrB_Info adapter_CFL_prepare(ParserResult parser_result, void *prepare_data) {
+    (void)prepare_data;
     TRY(adapter_CFL_prepare_common(parser_result, &state.adj_matrices, &state.terms_count, &state.nonterms_count,
                                    &state.rules, &state.rules_count, &state.graph_size));
 
@@ -75,7 +76,11 @@ static GrB_Info adapter_CFL_run() {
 // TODO: now check only count of reachibility pairs, make this more generic for other adapters
 static ResultType adapter_CFL_is_result_valid(size_t valid_result) {
     ResultType is_valid = RESULT_UNKNOWN;
-    TRY(adapter_CFL_is_result_valid_common(state.outputs[0], valid_result, &is_valid));
+    GrB_Info info = adapter_CFL_is_result_valid_common(state.outputs[0], valid_result, &is_valid);
+    if (info < GrB_SUCCESS) {
+        fprintf(stderr, "LAGraph failure (file %s, line %d): (%d, msg: %s) \n", __FILE__, __LINE__, info, state.msg);
+        return RESULT_UNKNOWN;
+    }
     return is_valid;
 }
 
@@ -106,7 +111,10 @@ static GrB_Info adapter_CFL_cleanup() {
 }
 
 // free LAGraph\GraphBLAS resources
-static GrB_Info adapter_CFL_teardown() { TRY(LAGraph_Finalize(state.msg)); }
+static GrB_Info adapter_CFL_teardown() {
+    TRY(LAGraph_Finalize(state.msg));
+    return GrB_SUCCESS;
+}
 
 // get the methods of the adapter
 AdapterMethods adapter_CFL_all_paths_get_methods() {

--- a/src/adapters/adapter_CFL_common.c
+++ b/src/adapters/adapter_CFL_common.c
@@ -235,6 +235,7 @@ GrB_Info adapter_CFL_prepare_common(ParserResult parser_result, GrB_Matrix **adj
 }
 
 GrB_Info adapter_CFL_init_outputs_common(GrB_Matrix **outputs, size_t nonterms_count, size_t graph_size, char *msg) {
+    (void)graph_size;
     TRY(LAGraph_Calloc((void **)outputs, nonterms_count, sizeof(GrB_Matrix), msg));
 
     // for (size_t i = 0; i < nonterms_count; i++) {

--- a/src/adapters/adapter_CFL_multsrc.c
+++ b/src/adapters/adapter_CFL_multsrc.c
@@ -47,7 +47,7 @@ static GrB_Info adapter_CFL_prepare(ParserResult parser_result, void *prepare_da
     TRY(adapter_CFL_prepare_common(parser_result, &state.adj_matrices, &state.terms_count, &state.nonterms_count,
                                    &state.rules, &state.rules_count, &state.graph_size));
 
-    adapter_CFL_init_src_nodes_common(&state.srcs, &state.source_count);
+    adapter_CFL_init_src_nodes_common(&state.srcs, &state.source_count, 0);
 
     return GrB_SUCCESS;
 }

--- a/src/adapters/adapter_CFL_multsrc.c
+++ b/src/adapters/adapter_CFL_multsrc.c
@@ -44,6 +44,7 @@ static GrB_Info adapter_CFL_setup() {
 //
 // adapter_CFL_prepare should be called just once for each config
 static GrB_Info adapter_CFL_prepare(ParserResult parser_result, void *prepare_data) {
+    (void)prepare_data;
     TRY(adapter_CFL_prepare_common(parser_result, &state.adj_matrices, &state.terms_count, &state.nonterms_count,
                                    &state.rules, &state.rules_count, &state.graph_size));
 
@@ -77,6 +78,7 @@ static GrB_Info adapter_CFL_run() {
 // TODO: now check only count of reachibility pairs, make this more generic for other adapters
 static ResultType adapter_CFL_is_result_valid(size_t valid_result) {
     // TODO: combine indexed matrices if initial nonterm is indexed
+    (void)valid_result;
     return RESULT_UNKNOWN;
 }
 
@@ -134,7 +136,10 @@ static GrB_Info adapter_CFL_cleanup() {
 }
 
 // free LAGraph\GraphBLAS resources
-static GrB_Info adapter_CFL_teardown() { TRY(LAGraph_Finalize(state.msg)); }
+static GrB_Info adapter_CFL_teardown() {
+    TRY(LAGraph_Finalize(state.msg));
+    return GrB_SUCCESS;
+}
 
 // get the methods of the adapter
 AdapterMethods adapter_CFL_multsrc_get_methods() {

--- a/src/adapters/adapter_CFL_multsrc_common.c
+++ b/src/adapters/adapter_CFL_multsrc_common.c
@@ -9,10 +9,14 @@
         }                                                                                                              \
     }
 
-GrB_Info adapter_CFL_init_src_nodes_common(GrB_Index **srcs, size_t *source_count) {
-    *source_count = 5;
-
-    *srcs = calloc(*source_count, sizeof(GrB_Index));
+GrB_Info adapter_CFL_init_src_nodes_common(GrB_Index **srcs, size_t *source_count, size_t graph_size) {
+    if (graph_size == 0) {
+        *source_count = 5;
+        *srcs = calloc(*source_count, sizeof(GrB_Index));
+    } else {
+        *source_count = graph_size;
+        *srcs = calloc(*source_count, sizeof(GrB_Index));
+    }
 
     if (srcs == NULL) {
         fprintf(stderr, "out of memory\n");
@@ -24,4 +28,4 @@ GrB_Info adapter_CFL_init_src_nodes_common(GrB_Index **srcs, size_t *source_coun
     }
 
     return GrB_SUCCESS;
-};
+}

--- a/src/adapters/adapter_CFL_multsrc_common.h
+++ b/src/adapters/adapter_CFL_multsrc_common.h
@@ -7,4 +7,4 @@
 #include <stdbool.h>
 
 // single method for sets source nodes
-GrB_Info adapter_CFL_init_src_nodes_common(GrB_Index **srcs, size_t *source_count);
+GrB_Info adapter_CFL_init_src_nodes_common(GrB_Index **srcs, size_t *source_count, size_t graph_size);

--- a/src/adapters/adapter_CFL_single_path.c
+++ b/src/adapters/adapter_CFL_single_path.c
@@ -44,6 +44,7 @@ static GrB_Info adapter_CFL_setup() {
 //
 // adapter_CFL_prepare should be called just once for each config
 static GrB_Info adapter_CFL_prepare(ParserResult parser_result, void *prepare_data) {
+    (void)prepare_data;
     TRY(adapter_CFL_prepare_common(parser_result, &state.adj_matrices, &state.terms_count, &state.nonterms_count,
                                    &state.rules, &state.rules_count, &state.graph_size));
 
@@ -74,7 +75,11 @@ static GrB_Info adapter_CFL_run() {
 // TODO: now check only count of reachibility pairs, make this more generic for other adapters
 static ResultType adapter_CFL_is_result_valid(size_t valid_result) {
     ResultType is_valid = RESULT_UNKNOWN;
-    TRY(adapter_CFL_is_result_valid_common(state.outputs[0], valid_result, &is_valid));
+    GrB_Info info = adapter_CFL_is_result_valid_common(state.outputs[0], valid_result, &is_valid);
+    if (info < GrB_SUCCESS) {
+        fprintf(stderr, "LAGraph failure (file %s, line %d): (%d, msg: %s) \n", __FILE__, __LINE__, info, state.msg);
+        return RESULT_UNKNOWN;
+    }
     return is_valid;
 }
 
@@ -105,7 +110,10 @@ static GrB_Info adapter_CFL_cleanup() {
 }
 
 // free LAGraph\GraphBLAS resources
-static GrB_Info adapter_CFL_teardown() { TRY(LAGraph_Finalize(state.msg)); }
+static GrB_Info adapter_CFL_teardown() {
+    TRY(LAGraph_Finalize(state.msg));
+    return GrB_SUCCESS;
+}
 
 // get the methods of the adapter
 AdapterMethods adapter_CFL_single_path_get_methods() {

--- a/src/parser.c
+++ b/src/parser.c
@@ -212,6 +212,58 @@ void explode_indices(Grammar *grammar, Graph *graph, SymbolList *list) {
     return;
 }
 
+// minimize graph nodes
+//
+// for example with 1000x1000 graph and only edge 0 -> 600 it makes 2x2 graph with edge 0 -> 1 with same label
+void *minimize_graph(Graph *graph) {
+    if (graph == NULL) {
+        fprintf(stderr, "\x1B[31m[ERROR]\033[0m graph is NULL\n");
+        exit(-1);
+    }
+
+    size_t old_node_count = graph->node_count;
+    for (size_t i = 0; i < graph->edge_count; i++) {
+        old_node_count = MAX(old_node_count, graph->edges[i].u + 1);
+        old_node_count = MAX(old_node_count, graph->edges[i].v + 1);
+    }
+
+    if (old_node_count == 0) {
+        graph->node_count = 0;
+        return NULL;
+    }
+
+    size_t *map = malloc(old_node_count * sizeof(*map));
+    if (map == NULL) {
+        fprintf(stderr, "\x1B[31m[ERROR]\033[0m out of memory\n");
+        abort();
+    }
+
+    for (size_t i = 0; i < old_node_count; i++) {
+        map[i] = (size_t)-1;
+    }
+
+    for (size_t i = 0; i < graph->edge_count; i++) {
+        map[graph->edges[i].u] = 0;
+        map[graph->edges[i].v] = 0;
+    }
+
+    size_t new_node_count = 0;
+    for (size_t i = 0; i < old_node_count; i++) {
+        if (map[i] != (size_t)-1) {
+            map[i] = new_node_count++;
+        }
+    }
+
+    for (size_t i = 0; i < graph->edge_count; i++) {
+        graph->edges[i].u = map[graph->edges[i].u];
+        graph->edges[i].v = map[graph->edges[i].v];
+    }
+
+    graph->node_count = new_node_count;
+
+    return map;
+}
+
 GrB_Matrix *get_grb_matrices_from_graph(Graph graph, SymbolList *list) {
     explode_indices(&(Grammar){.rules = NULL, .rules_count = 0}, &graph, list);
     SymbolData *symbol_datas = calloc(list->count, sizeof(SymbolData));

--- a/src/parser.h
+++ b/src/parser.h
@@ -86,6 +86,11 @@ typedef struct {
 Graph process_graph(FILE *graph_file, SymbolList *symbol_list);
 GrB_Matrix *get_grb_matrices_from_graph(Graph graph, SymbolList *list);
 
+// minimize graph nodes
+//
+// for example with 1000x1000 graph and only edge 0 -> 600 it makes 2x2 graph with edge 0 -> 1 with same label
+void *minimize_graph(Graph *graph);
+
 // before: homka_i
 // after: homka_1
 //        homka_2

--- a/src/rsm.c
+++ b/src/rsm.c
@@ -411,18 +411,18 @@ static CFG_RSM *rsm_create_aa_template(bool exploded, size_t n, SymbolList *term
     return rsm;
 }
 
-static CFG_RSM *rsm_create_c_alias_template(void) {
-    CFG_RSM *rsm = rsm_init(NULL);
+static CFG_RSM *rsm_create_c_alias_template(SymbolList *terms) {
+    CFG_RSM *rsm = rsm_init(terms);
 
     rsm_add_nonterm(rsm, "S");
     rsm_add_nonterm(rsm, "V");
 
     rsm_set_start_nonterm(rsm, "S");
 
-    rsm_add_term(rsm, "d_rev");
+    rsm_add_term(rsm, "d_r");
     rsm_add_term(rsm, "d");
     rsm_add_term(rsm, "a");
-    rsm_add_term(rsm, "a_rev");
+    rsm_add_term(rsm, "a_r");
 
     rsm_add_state(rsm, "S", "0");
     rsm_add_state(rsm, "S", "1");
@@ -432,7 +432,7 @@ static CFG_RSM *rsm_create_c_alias_template(void) {
     rsm_set_start_state(rsm, "S", "0");
     rsm_add_final_state(rsm, "S", "3");
 
-    rsm_add_edge(rsm, "S", "0", "1", "d_rev");
+    rsm_add_edge(rsm, "S", "0", "1", "d_r");
     rsm_add_edge(rsm, "S", "1", "2", "V");
     rsm_add_edge(rsm, "S", "2", "3", "d");
 
@@ -448,9 +448,9 @@ static CFG_RSM *rsm_create_c_alias_template(void) {
     rsm_add_final_state(rsm, "V", "3");
 
     rsm_add_edge(rsm, "V", "0", "2", "a");
-    rsm_add_edge(rsm, "V", "0", "0", "a_rev");
+    rsm_add_edge(rsm, "V", "0", "0", "a_r");
     rsm_add_edge(rsm, "V", "0", "1", "S");
-    rsm_add_edge(rsm, "V", "1", "0", "a_rev");
+    rsm_add_edge(rsm, "V", "1", "0", "a_r");
     rsm_add_edge(rsm, "V", "1", "2", "a");
     rsm_add_edge(rsm, "V", "2", "2", "a");
     rsm_add_edge(rsm, "V", "2", "3", "S");
@@ -629,8 +629,8 @@ static CFG_RSM *rsm_create_java_points_to_template(bool exploded, size_t n, Symb
     return rsm;
 }
 
-static CFG_RSM *rsm_create_rdf_hierarchy_template(void) {
-    CFG_RSM *rsm = rsm_init(NULL);
+static CFG_RSM *rsm_create_rdf_hierarchy_template(SymbolList *terms) {
+    CFG_RSM *rsm = rsm_init(terms);
 
     rsm_add_nonterm(rsm, "S");
     rsm_set_start_nonterm(rsm, "S");
@@ -791,13 +791,13 @@ CFG_RSM *rsm_create_template(RSM_Template template, bool exploded, size_t n, Sym
         return rsm_create_aa_template(exploded, n, terms);
 
     case RSM_TEMPLATE_C_ALIAS:
-        return rsm_create_c_alias_template();
+        return rsm_create_c_alias_template(terms);
 
     case RSM_TEMPLATE_JAVA_POINTS_TO:
         return rsm_create_java_points_to_template(exploded, n, terms);
 
     case RSM_TEMPLATE_RDF_HIERARCHY:
-        return rsm_create_rdf_hierarchy_template();
+        return rsm_create_rdf_hierarchy_template(terms);
 
     default:
         fprintf(stderr, "unknown RSM template: %d\n", (int)template);

--- a/src/rsm.c
+++ b/src/rsm.c
@@ -75,14 +75,14 @@ static void rsm_box_print(CFG_RSM_Box *box, SymbolList *terms, SymbolList *nonte
     printf("    start_state: %s\n", symbol_list_get_str(&box->states, box->start_state));
     printf("    edges:\n");
     for (size_t i = 0; i < box->edges.count; i++) {
-        char *start_state = symbol_list_get_str(&box->states, box->edges.data[i].start);
-        char *label = NULL;
+        const char *start_state = symbol_list_get_str(&box->states, box->edges.data[i].start);
+        const char *label = NULL;
         if (box->edges.data[i].is_term) {
             label = symbol_list_get_str(terms, box->edges.data[i].label);
         } else {
             label = symbol_list_get_str(nonterms, box->edges.data[i].label);
         }
-        char *end_state = symbol_list_get_str(&box->states, box->edges.data[i].end);
+        const char *end_state = symbol_list_get_str(&box->states, box->edges.data[i].end);
         printf("        %s -[%s]-> %s\n", start_state, label, end_state);
     }
     printf("    final_states:");

--- a/src/symbol_list.c
+++ b/src/symbol_list.c
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-Symbol symbol_create(char *str) {
+Symbol symbol_create(const char *str) {
     Symbol result = {0};
 
     size_t len = strlen(str);
@@ -78,7 +78,7 @@ void symbol_list_print(SymbolList list) {
     }
 }
 
-int symbol_list_get_index_str(SymbolList *list, char *str) {
+int symbol_list_get_index_str(const SymbolList *list, const char *str) {
     for (size_t i = 0; i < list->count; i++) {
         if (strcmp(list->symbols[i].label, str) == 0) {
             return i;
@@ -88,7 +88,7 @@ int symbol_list_get_index_str(SymbolList *list, char *str) {
     return -1;
 }
 
-int symbol_list_add_str(SymbolList *list, char *str, bool is_nonterm) {
+int symbol_list_add_str(SymbolList *list, const char *str, bool is_nonterm) {
     int index = symbol_list_get_index_str(list, str);
     if (index != -1) {
         if (is_nonterm)

--- a/src/symbol_list.h
+++ b/src/symbol_list.h
@@ -24,7 +24,7 @@ typedef struct {
     size_t capacity;
 } SymbolData;
 
-Symbol symbol_create(char *str);
+Symbol symbol_create(const char *str);
 void symbol_free(Symbol *sym);
 
 // return new string with numeration
@@ -36,7 +36,7 @@ void symbol_list_print(SymbolList list);
 
 // return index of Symbol with "str" label in SymbolList
 // return -1 if Symbol with "str" label not found
-int symbol_list_get_index_str(SymbolList *list, char *str);
+int symbol_list_get_index_str(const SymbolList *list, const char *str);
 
 // return label of Symbol with "index" in SymbolList
 // raise error if Symbol with "index" not found
@@ -46,7 +46,7 @@ const char *symbol_list_get_str(const SymbolList *list, size_t index);
 // if Symbol with "str" label already exists in SymbolList, return its index
 //
 // change nonterm field if fount term symbol with "str" label and "is_nonterm" is true
-int symbol_list_add_str(SymbolList *list, char *str, bool is_nonterm);
+int symbol_list_add_str(SymbolList *list, const char *str, bool is_nonterm);
 void symbol_list_swap(SymbolList *list, size_t i1, size_t i2);
 void symbol_list_free(SymbolList *list);
 


### PR DESCRIPTION
- New Makefile
- Init source nodes for multsrc algorithms now can init all nodes
- Fix `c_alias` and `rdf` rsm templates
- Fix skipping to giving initial terms to rsm templates
- Add CFL config for algorithms that works relativly fast
- Fix all warnings